### PR TITLE
extend airbnb config

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ module.exports = {
     sourceType: 'module'
   },
 
+  extends: [
+    'airbnb/base'
+  ],
+
   env: {
     es6: true,
     mocha: true,
@@ -37,6 +41,7 @@ module.exports = {
     'object-curly-spacing': [ 2, 'always' ],
     quotes: [ 2, 'single' ],
     semi: [ 2, 'never' ],
+    'no-unexpected-multiline': 2,
     'space-before-blocks': [ 2, 'always' ],
     'space-before-function-paren': [ 2, 'always' ],
     'no-warning-comments': [ 1, { terms: [ 'todo', 'fixme' ], location: 'anywhere' } ],

--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ module.exports = {
     'no-undef': 2,
     'no-underscore-dangle': 0,
     'no-unused-vars': 2,
-    'no-var': 2,
     'object-curly-spacing': [ 2, 'always' ],
     quotes: [ 2, 'single' ],
     semi: [ 2, 'never' ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "peerDependencies": {
     "eslint": ">=2.0",
     "eslint-config-airbnb": ">=7.0",
-    "eslint-plugin-jsx-a11y": ">=1.0",
     "eslint-plugin-react": ">=4.0",
     "babel-eslint": ">=6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-commercetools",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Commercetools's eslint config, following our styleguide",
   "main": "index.js",
   "private": false,
@@ -16,7 +16,10 @@
   "homepage": "https://github.com/commercetools/eslint-config",
   "peerDependencies": {
     "eslint": ">=2.0",
-    "eslint-plugin-react": ">=4.0"
+    "eslint-config-airbnb": ">=7.0",
+    "eslint-plugin-jsx-a11y": ">=1.0",
+    "eslint-plugin-react": ">=4.0",
+    "babel-eslint": ">=6.0"
   },
   "keywords": [
     "eslint",

--- a/with-react.js
+++ b/with-react.js
@@ -1,6 +1,9 @@
 module.exports = {
 
-  extends: 'commercetools',
+  extends: [
+    'airbnb/base',
+    'commercetools'
+  ],
 
   plugins: ['react'],
 


### PR DESCRIPTION
This PR
- makes the commercetools config extend `eslint-config-airbnb`
- adds `babel-eslint` as a peer dependency (was missing previously)
- adds rule [no-unexpected-multiline](http://eslint.org/docs/rules/no-unexpected-multiline) to prevent errors arising when not using semis
- bumps version to 2.0.0

Updating any project using this config will result in a LOT of new issues and likely fail the linter.
The dependent projects will also need to install the new peer dependencies.