### PR TITLE
Use peerDependencies because of incompatibilities between npm 2 - 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ Table of Contents
     * [License](#license)
 
 ## Usage
-Add it as an npm dev-dependency
+Add it as an npm devDependency, as well as all the necessary [peerDependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).
 
 ```bash
-$ npm i eslint-config-commercetools --save-dev
+$ npm install --save-dev eslint-config-commercetools eslint@^#.#.# eslint-config-airbnb@^#.#.# eslint-plugin-jsx-a11y@^#.#.# eslint-plugin-import@^#.#.# eslint-plugin-react@^#.#.#
 ```
-or add this to your package.json
 
-```json
-{
-  "devDependencies": {
-    "eslint-config-commercetools": "latest"
-  }
-}
+You can alternatively run this script, which basically produces the same command above:
+
+```bash
+(
+  export PKG=eslint-config-commercetools;
+  npm info "$PKG" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG"
+)
 ```
 
 Create a `.eslintrc` file with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-commercetools",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Commercetools's eslint config, following our styleguide",
   "main": "index.js",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -14,13 +14,12 @@
     "url": "https://github.com/commercetools/eslint-config/issues"
   },
   "homepage": "https://github.com/commercetools/eslint-config",
-  "dependencies": {
-    "babel-eslint": "^6.1.2",
-    "eslint": "^3.4.0",
-    "eslint-config-airbnb": "^11.0.0",
-    "eslint-plugin-import": "^1.15.0",
-    "eslint-plugin-jsx-a11y": "^2.2.1",
-    "eslint-plugin-react": "^6.2.0"
+  "peerDependencies": {
+    "eslint": ">=3",
+    "eslint-config-airbnb": ">=11",
+    "eslint-plugin-import": ">=1",
+    "eslint-plugin-jsx-a11y": ">=2",
+    "eslint-plugin-react": ">=6"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-commercetools",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Commercetools's eslint config, following our styleguide",
   "main": "index.js",
   "private": false,


### PR DESCRIPTION
#### Summary
Having normal dependencies doesn't work for npm@2.
We should use `peerDependencies` as also [recommended by eslint](http://eslint.org/docs/developer-guide/shareable-configs).

#### Description
If we define the dependencies as normal dependencies, those will be installed differently based on
the npm version. With npm@3 the dependencies are flattened on the top level and they are available
to all libraries. With npm@2 those dependencies will be only available to this package, making it
impossible to use eslint properly.

#### Reviewers

- [ ] Reviewer 1 has approved the PR
- [ ] Reviewer 2 has approved the PR
