### PR TITLE
chore(travis-CI): add node v6 & v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - '4'
+  - '6'
+  - '8'
 script:
   - npm run lint
 notifications:


### PR DESCRIPTION
#### Summary
Add node v8 to CI and remove v4

#### Description
- Add of node v6 & v8 to CI and remove v4 in eslint-config


Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)